### PR TITLE
Implement start delay, fix cancellation and optimize tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests
-        run: go test -v .
+        run: go test -v -race ./...
 
   coverage:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ So the example above means:
 This is especially helpful for stuff like incremental content rendering, when you need
 to ensure that the system converges to the last known state.
 
+### Debounce jobs with a start delay
+
+Sometimes it is desirable to delay the actual start of a job and wait until some time has passed and no other start of
+the same pipeline was triggered. This is especially useful with `queue_strategy: replace` where this can act as a
+debounce of events (e.g. a user in an application performs some actions and a pipeline run is triggered for each action).
+
+The delay can be configured on the pipeline level with the `start_delay` property. The value is given as duration
+in form of a zero or positive decimal value with a time unit ("ms", "s", "m", "h" are supported): 
+
+```yaml
+pipelines:
+  do_something:
+    queue_limit: 1
+    queue_strategy: replace
+    concurrency: 1
+    # Queues a run of the job and only starts it after 10 seconds have passed (if no other run was triggered which replaced the queued job)
+    start_delay: 10s
+    tasks: # as usual
+```
+
 
 ### Disabling Fail-Fast Behavior
 
@@ -185,7 +205,7 @@ pipelines:
 
 By default, we never delete any runs. For many projects, it is useful to configure this to keep the
 consumed disk space under control. This can be done on a per-pipeline level; using one of the two configuration
-settings `retention_period_hours` and `retention_count`:
+settings `retention_period` (decimal with time unit as in `start_delay`) and `retention_count`.
 
 As an example, let's configure we only are interested on the last 10 pipeline runs:
 
@@ -201,7 +221,7 @@ Alternatively, we can delete the data after two days:
 ```yaml
 pipelines:
   do_something:
-    retention_period_hours: 48
+    retention_period: 48h
     tasks: # as usual
 ```
 

--- a/definition/loader.go
+++ b/definition/loader.go
@@ -52,13 +52,9 @@ func (d *PipelinesDef) Load(path string) error {
 			return errors.Errorf("pipeline %q was already declared in %s", pipelineName, p.SourcePath)
 		}
 
-		for taskName, taskDef := range pipelineDef.Tasks {
-			for _, dependentTask := range taskDef.DependsOn {
-				_, exists := pipelineDef.Tasks[dependentTask]
-				if !exists {
-					return errors.Errorf("missing task %q in pipeline %q referenced in depends_on of task %q", dependentTask, pipelineName, taskName)
-				}
-			}
+		err := pipelineDef.validate()
+		if err != nil {
+			return errors.Wrapf(err, "invalid pipeline definition %q", pipelineName)
 		}
 
 		pipelineDef.SourcePath = path

--- a/definition/loader_test.go
+++ b/definition/loader_test.go
@@ -21,5 +21,5 @@ func TestLoadRecursively_WithDuplicate(t *testing.T) {
 
 func TestLoadRecursively_WithMissingDependency(t *testing.T) {
 	_, err := LoadRecursively("../test/fixtures/missingDep.yml")
-	require.EqualError(t, err, `loading ../test/fixtures/missingDep.yml: missing task "not_existing" in pipeline "test_it" referenced in depends_on of task "test"`)
+	require.EqualError(t, err, `loading ../test/fixtures/missingDep.yml: invalid pipeline definition "test_it": missing task "not_existing" referenced in depends_on of task "test"`)
 }

--- a/examples/pipelines.yml
+++ b/examples/pipelines.yml
@@ -88,6 +88,26 @@ pipelines:
 
   replace_it:
     queue_strategy: replace
+    queue_limit: 1
+    tasks:
+      lint:
+        script:
+          - echo "Starting something busy"
+          - sleep 2
+          - echo "25% done"
+          - sleep 3
+          - echo "50% done"
+          - sleep 4
+          - echo "75% done"
+          - sleep 2
+          - echo "100% done"
+          - echo -n "Last line"
+
+  replace_it_with_delay:
+    concurrency: 1
+    queue_strategy: replace
+    queue_limit: 1
+    start_delay: 15s
     tasks:
       lint:
         script:

--- a/prunner.go
+++ b/prunner.go
@@ -160,15 +160,6 @@ type jobTasks []jobTask
 
 type scheduleAction int
 
-func (a scheduleAction) in(actions ...scheduleAction) bool {
-	for _, action := range actions {
-		if a == action {
-			return true
-		}
-	}
-	return false
-}
-
 const (
 	scheduleActionStart scheduleAction = iota
 	scheduleActionQueue

--- a/prunner.go
+++ b/prunner.go
@@ -2,11 +2,12 @@ package prunner
 
 import (
 	"context"
-	"github.com/Flowpack/prunner/store"
+	"fmt"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
+
+	"github.com/Flowpack/prunner/store"
 
 	"github.com/apex/log"
 	"github.com/friendsofgo/errors"
@@ -43,6 +44,9 @@ type PipelineRunner struct {
 	// Mutex for reading or writing jobs and job state
 	mx               sync.RWMutex
 	createTaskRunner func() taskctl.Runner
+
+	// Wait group for waiting for asynchronous operations like job.Cancel
+	wg sync.WaitGroup
 }
 
 // NewPipelineRunner creates the central data structure which controls the full runner state; so this knows what is currently running
@@ -88,9 +92,10 @@ func NewPipelineRunner(ctx context.Context, defs *definition.PipelinesDef, creat
 // PipelineJob is a single execution context (a single run of a single pipeline). Can be scheduled (in the waitListByPipeline of PipelineRunner),
 // or currently running (jobsByID / jobsByPipeline in PipelineRunner)
 type PipelineJob struct {
-	ID        uuid.UUID
-	Pipeline  string
-	Variables map[string]interface{}
+	ID         uuid.UUID
+	Pipeline   string
+	Variables  map[string]interface{}
+	StartDelay time.Duration
 
 	Completed bool
 	Canceled  bool
@@ -107,6 +112,7 @@ type PipelineJob struct {
 
 	sched      *taskctl.Scheduler
 	taskRunner runner.Runner
+	startTimer *time.Timer
 }
 
 func (j *PipelineJob) isRunning() bool {
@@ -154,9 +160,19 @@ type jobTasks []jobTask
 
 type scheduleAction int
 
+func (a scheduleAction) in(actions ...scheduleAction) bool {
+	for _, action := range actions {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}
+
 const (
 	scheduleActionStart scheduleAction = iota
 	scheduleActionQueue
+	scheduleActionQueueDelay
 	scheduleActionReplace
 	scheduleActionNoQueue
 	scheduleActionQueueFull
@@ -194,16 +210,24 @@ func (r *PipelineRunner) ScheduleAsync(pipeline string, opts ScheduleOpts) (*Pip
 	defer r.requestPersist()
 
 	job := &PipelineJob{
-		ID:        id,
-		Pipeline:  pipeline,
-		Created:   time.Now(),
-		Tasks:     buildJobTasks(pipelineDef.Tasks),
-		Variables: opts.Variables,
-		User:      opts.User,
+		ID:         id,
+		Pipeline:   pipeline,
+		Created:    time.Now(),
+		Tasks:      buildJobTasks(pipelineDef.Tasks),
+		Variables:  opts.Variables,
+		User:       opts.User,
+		StartDelay: pipelineDef.StartDelay,
 	}
 
 	r.jobsByID[id] = job
 	r.jobsByPipeline[pipeline] = append(r.jobsByPipeline[pipeline], job)
+
+	if job.StartDelay > 0 {
+		// A delayed job is a job on the wait list that is started by a function after a delay
+		job.startTimer = time.AfterFunc(job.StartDelay, func() {
+			r.StartDelayedJob(id)
+		})
+	}
 
 	switch action {
 	case scheduleActionQueue:
@@ -221,6 +245,11 @@ func (r *PipelineRunner) ScheduleAsync(pipeline string, opts ScheduleOpts) (*Pip
 		waitList := r.waitListByPipeline[pipeline]
 		previousJob := waitList[len(waitList)-1]
 		previousJob.Canceled = true
+		if previousJob.startTimer != nil {
+			// Stop timer and unset reference for clean up
+			previousJob.startTimer.Stop()
+			previousJob.startTimer = nil
+		}
 		waitList[len(waitList)-1] = job
 
 		log.
@@ -324,7 +353,8 @@ func (r *PipelineRunner) startJob(job *PipelineJob) {
 		log.
 			WithError(err).
 			WithField("jobID", job.ID).
-			WithField("pipeline", job.ID)
+			WithField("pipeline", job.Pipeline).
+			Error("Failed to build pipeline graph")
 
 		job.LastError = err
 		job.Canceled = true
@@ -468,9 +498,15 @@ func (r *PipelineRunner) startJobsOnWaitList(pipeline string) {
 	// Check wait list if another job is queued
 	waitList := r.waitListByPipeline[pipeline]
 
-	// Schedule as many jobs as are schedulable
-	for len(waitList) > 0 && r.resolveScheduleAction(pipeline) == scheduleActionStart {
+	// Schedule as many jobs as are schedulable (also process if the schedule action is start delay and check individual jobs if they can be started)
+	for len(waitList) > 0 && r.resolveDequeueJobAction(waitList[0]) == scheduleActionStart {
 		queuedJob := waitList[0]
+		// Queued job has a start delay timer set - wait for it to fire
+		if queuedJob.startTimer != nil {
+			// TODO We need to check if we rather need to skip only this job and continue to process other jobs on the queue
+			break
+		}
+
 		waitList = waitList[1:]
 
 		r.startJob(queuedJob)
@@ -547,8 +583,10 @@ func (r *PipelineRunner) runningJobsCount(pipeline string) int {
 func (r *PipelineRunner) resolveScheduleAction(pipeline string) scheduleAction {
 	pipelineDef := r.defs.Pipelines[pipeline]
 
+	// If a start delay is set, we will always queue the job, otherwise we check if the number of running jobs
+	// exceed the maximum concurrency
 	runningJobsCount := r.runningJobsCount(pipeline)
-	if runningJobsCount >= pipelineDef.Concurrency {
+	if runningJobsCount >= pipelineDef.Concurrency || pipelineDef.StartDelay > 0 {
 		// Check if jobs should be queued if concurrency factor is exceeded
 		if pipelineDef.QueueLimit != nil && *pipelineDef.QueueLimit == 0 {
 			return scheduleActionNoQueue
@@ -571,6 +609,15 @@ func (r *PipelineRunner) resolveScheduleAction(pipeline string) scheduleAction {
 	return scheduleActionStart
 }
 
+func (r *PipelineRunner) resolveDequeueJobAction(job *PipelineJob) scheduleAction {
+	// Start the job if it had a start delay but the timer finished
+	if job.StartDelay > 0 && job.startTimer == nil {
+		return scheduleActionStart
+	}
+
+	return r.resolveScheduleAction(job.Pipeline)
+}
+
 func (r *PipelineRunner) isSchedulable(pipeline string) bool {
 	action := r.resolveScheduleAction(pipeline)
 	switch action {
@@ -579,6 +626,8 @@ func (r *PipelineRunner) isSchedulable(pipeline string) bool {
 	case scheduleActionQueue:
 		fallthrough
 	case scheduleActionStart:
+		return true
+	case scheduleActionQueueDelay:
 		return true
 	}
 	return false
@@ -649,10 +698,14 @@ func (r *PipelineRunner) SaveToStore() {
 		Jobs: make([]store.PersistedJob, 0, len(r.jobsByID)),
 	}
 
-	// remove jobs whose retention period has expired
+	// Remove jobs whose retention period has expired
 	for _, jobsInPipeline := range r.jobsByPipeline {
-		pipelineJobBy(byCreationTimeDesc).Sort(jobsInPipeline)
-		for i, job := range jobsInPipeline {
+		// Make a copy of the slice before sorting to prevent data races (we only have a read lock here)
+		sortedJobsInPipeline := make([]*PipelineJob, len(jobsInPipeline))
+		copy(sortedJobsInPipeline, jobsInPipeline)
+		pipelineJobBy(byCreationTimeDesc).Sort(sortedJobsInPipeline)
+
+		for i, job := range sortedJobsInPipeline {
 			shouldRemoveJob, removalReason := r.determineIfJobShouldBeRemoved(i, job)
 
 			if shouldRemoveJob {
@@ -747,21 +800,21 @@ func (r *PipelineRunner) determineIfJobShouldBeRemoved(index int, job *PipelineJ
 	}
 
 	if job.Start == nil && !job.Canceled {
-		// always keep jobs of waitlist.
-		return false, "keeping job of waitlist"
+		// always keep jobs on wait list
+		return false, "Keeping job on wait list"
 	}
 
 	if !job.Completed && !job.Canceled {
-		// always keep jobs which are not yet in some "finished" state.
-		return false, "keeping non-finished jobs"
+		// always keep jobs which are not yet in some "finished" state
+		return false, "Keeping non-finished job"
 	}
 
-	if pipelineDef.RetentionPeriodHours > 0 && -time.Until(job.Created) > time.Duration(pipelineDef.RetentionPeriodHours)*time.Hour {
-		return true, "Retention Period of " + strconv.Itoa(pipelineDef.RetentionPeriodHours) + " hours reached"
+	if pipelineDef.RetentionPeriod > 0 && time.Since(job.Created) > pipelineDef.RetentionPeriod {
+		return true, fmt.Sprintf("Retention period of %s reached", pipelineDef.RetentionPeriod.String())
 	}
 
 	if pipelineDef.RetentionCount > 0 && index >= pipelineDef.RetentionCount {
-		return true, "Retention Count of " + strconv.Itoa(pipelineDef.RetentionCount) + " reached"
+		return true, fmt.Sprintf("Retention count of %d reached", pipelineDef.RetentionCount)
 	}
 
 	return false, ""
@@ -789,6 +842,11 @@ func (r *PipelineRunner) cancelJobInternal(id uuid.UUID) error {
 		return ErrJobNotFound
 	}
 
+	if job.Canceled {
+		// Canceling an already canceled job is not an error
+		return nil
+	}
+
 	if job.Completed {
 		return errJobAlreadyCompleted
 	}
@@ -796,19 +854,56 @@ func (r *PipelineRunner) cancelJobInternal(id uuid.UUID) error {
 	if job.Start == nil {
 		return errJobNotStarted
 	}
+
 	log.
 		WithField("component", "runner").
 		WithField("pipeline", job.Pipeline).
 		WithField("jobID", job.ID).
 		Debugf("Canceling job")
 
+	if job.sched == nil {
+		log.
+			WithField("component", "runner").
+			WithField("pipeline", job.Pipeline).
+			WithField("jobID", job.ID).
+			Warnf("Failed assertion: scheduler of job is nil")
+		return nil
+	}
+
+	cancelFunc := job.sched.Cancel
+
+	r.wg.Add(1)
 	go (func() {
-		if job.sched != nil {
-			job.sched.Cancel()
-		}
+		cancelFunc()
+		r.wg.Done()
 	})()
 
 	return nil
+}
+
+func (r *PipelineRunner) StartDelayedJob(id uuid.UUID) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+
+	job, ok := r.jobsByID[id]
+	if !ok {
+		log.
+			WithField("component", "runner").
+			WithField("jobID", id).
+			Error("Failed to find job to start after delay")
+		return
+	}
+
+	if job.Canceled {
+		return
+	}
+
+	// Unset start timer since it is done to allow immediate processing of job
+	// (e.g. if it gets eligible to execute after some other job finished)
+	job.startTimer = nil
+
+	// Start pending jobs on wait list (should run delayed job)
+	r.startJobsOnWaitList(job.Pipeline)
 }
 
 func buildJobFromPersistedJob(pJob store.PersistedJob) *PipelineJob {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -205,8 +205,9 @@ func TestServer_JobCancel(t *testing.T) {
 
 	pRunner, err := prunner.NewPipelineRunner(ctx, defs, func() taskctl.Runner {
 		return &test.MockRunner{
-			OnRun: func(t *task.Task) {
+			OnRun: func(t *task.Task) error {
 				wg.Wait()
+				return nil
 			},
 			OnCancel: func() {
 				wg.Done()

--- a/test/mock_runner.go
+++ b/test/mock_runner.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/apex/log"
 	"github.com/taskctl/taskctl/pkg/task"
+
 	"github.com/Flowpack/prunner/taskctl"
 )
 
 type MockRunner struct {
 	onTaskChange func(t *task.Task)
-	OnRun        func(t *task.Task)
+	OnRun        func(t *task.Task) error
 	OnCancel     func()
 }
 
@@ -29,8 +30,10 @@ func (m *MockRunner) Run(t *task.Task) error {
 	log.WithField("component", "mockRunner").Debugf("Running task %s", t.Name)
 	time.Sleep(1 * time.Millisecond)
 
+	var err error
+
 	if m.OnRun != nil {
-		m.OnRun(t)
+		err = m.OnRun(t)
 	}
 
 	t.End = time.Now()
@@ -38,7 +41,7 @@ func (m *MockRunner) Run(t *task.Task) error {
 		m.onTaskChange(t)
 	}
 
-	return nil
+	return err
 }
 
 func (m *MockRunner) Cancel() {

--- a/test/mock_store.go
+++ b/test/mock_store.go
@@ -2,15 +2,19 @@ package test
 
 import (
 	"bytes"
-	"github.com/Flowpack/prunner/store"
+	"sync"
+
 	"github.com/friendsofgo/errors"
 	jsoniter "github.com/json-iterator/go"
+
+	"github.com/Flowpack/prunner/store"
 )
 
 var json = jsoniter.ConfigFastest
 
 type mockStore struct {
 	storedBytes []byte
+	mx          sync.Mutex
 }
 
 var _ store.DataStore = &mockStore{}
@@ -19,7 +23,16 @@ func NewMockStore() *mockStore {
 	return &mockStore{}
 }
 
+func (m *mockStore) Set(data []byte) {
+	m.mx.Lock()
+	m.storedBytes = data
+	m.mx.Unlock()
+}
+
 func (m *mockStore) Load() (*store.PersistedData, error) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
 	var result store.PersistedData
 	if len(m.storedBytes) == 0 {
 		return &store.PersistedData{}, nil
@@ -33,6 +46,11 @@ func (m *mockStore) Load() (*store.PersistedData, error) {
 }
 
 func (m *mockStore) Save(data *store.PersistedData) error {
+	// Normally we do not need to lock, since the Save method would be called sequentially in prunner by requestPersist,
+	// but tests call SaveToStore directly which can lead to data races.
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
 	buf := new(bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(data)
 	if err != nil {


### PR DESCRIPTION
- Resolves #13 by adding a new `start_delay` pipeline option
- Fixes a possible issue in #8 by using a wait group in TaskRunner
  cancellation
- Updates tests to use mock runner with simulated tasks where
  possible to reduce test run time
- Added race detector to test runs and fixed some data races
  (mostly in tests)