### PR TITLE
!!! BUGFIX: fix huge memory leak where job output was stored in memory for a long time - Disables {{ .Output }} and {{ .Tasks.XYZ.Output }} placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 .env*
 
 dist/
+/heapdump*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,44 @@
 
 This is NOT a fully featured CI pipeline solution.
 
+<!-- TOC -->
+  * [Badges](#badges)
+  * [Components](#components)
+    * [prunner (this repository)](#prunner--this-repository-)
+    * [prunner-ui](#prunner-ui)
+    * [Flowpack.Prunner](#flowpackprunner)
+  * [User guide](#user-guide)
+    * [Main concepts](#main-concepts)
+    * [A simple pipeline](#a-simple-pipeline)
+    * [Task dependencies](#task-dependencies)
+    * [Job variables](#job-variables)
+    * [Environment variables](#environment-variables)
+      * [Dotenv files](#dotenv-files)
+    * [Limiting concurrency](#limiting-concurrency)
+    * [The wait list](#the-wait-list)
+    * [Debounce jobs with a start delay](#debounce-jobs-with-a-start-delay)
+    * [Disabling fail-fast behavior](#disabling-fail-fast-behavior)
+    * [Configuring retention period](#configuring-retention-period)
+    * [Handling of child processes](#handling-of-child-processes)
+    * [Graceful shutdown](#graceful-shutdown)
+    * [Reloading definitions and watching for changes](#reloading-definitions-and-watching-for-changes)
+    * [Persistent job state](#persistent-job-state)
+  * [Running prunner](#running-prunner)
+    * [CLI Reference](#cli-reference)
+    * [Docker](#docker)
+  * [Development](#development)
+    * [Requirements](#requirements)
+    * [Running locally](#running-locally)
+    * [IDE Setup (IntelliJ/GoLand)](#ide-setup--intellijgoland-)
+    * [Building for different operating systems.](#building-for-different-operating-systems)
+    * [Running Tests](#running-tests)
+    * [Memory Leak Debugging](#memory-leak-debugging)
+    * [Generate OpenAPI (Swagger) spec](#generate-openapi--swagger--spec)
+    * [Releasing](#releasing)
+  * [Security concept](#security-concept)
+  * [License](#license)
+<!-- TOC -->
+
 ## Badges
 
 [![Release](https://img.shields.io/github/release/Flowpack/prunner.svg?style=for-the-badge)](https://github.com/Flowpack/prunner/releases/latest)
@@ -375,6 +413,25 @@ For interacting with the API, you need a JWT token which you can generate for de
 ```bash
 go run ./cmd/prunner debug
 ```
+### IDE Setup (IntelliJ/GoLand)
+
+- Please install [Go](https://plugins.jetbrains.com/plugin/9568-go) Plugin in IntelliJ.
+- In the Settings of IntelliJ: Activate `Languages & Frameworks -> Go -> Go Modules` - `Enable Go Modules Integration`
+- Open a Go File. At the top of the screen the following message appears: `GOROOT is not defined` -> `Setup GOROOT` -> `/usr/local/opt/go/libexec`
+- If autocompletion / syntax check shows lots of things red, try the following two steps:
+  - restart the IDE
+  - if this does not help, `File -> Invalidate Caches`
+
+- Run / Debug in IDE:
+    - `Run -> Edit Configurations`
+    - `Add new Run Configuration` -> `Go Build`
+    - Files: `.../cmd/prunner/main.go`
+    - Working Directory: `.../`
+
+- Tests:
+    - `Run -> Edit Configurations`
+    - `Add new Run Configuration` -> `Go Test`
+    - Test Kind: Package (otherwise you cannot set breakpoints)
 
 ### Building for different operating systems.
 
@@ -405,6 +462,21 @@ Then, to run the linter, use:
 
 ```bash
 golangci-lint run
+```
+
+### Memory Leak Debugging
+
+to find memory leaks, you can run `prunner` in the following way:
+
+```bash
+# start prunner in profiling mode with the config from test/memory_leak_debugging/pipelines.yml
+./dev.sh memory-leak-start
+
+# run a pipeline which creates many MB of log output (possibly multiple times)
+./dev.sh start-pipeline memleak1
+
+# analyze heap dump
+./dev.sh analyze-heapdump
 ```
 
 ### Generate OpenAPI (Swagger) spec

--- a/app/debug_cmd.go
+++ b/app/debug_cmd.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"fmt"
 	"github.com/apex/log"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/urfave/cli/v2"
+	"os"
 )
 
 func newDebugCmd() *cli.Command {
@@ -21,7 +23,12 @@ func newDebugCmd() *cli.Command {
 			claims := make(map[string]interface{})
 			jwtauth.SetIssuedNow(claims)
 			_, tokenString, _ := tokenAuth.Encode(claims)
-			log.Infof("Send the following HTTP header for JWT authorization:\n    Authorization: Bearer %s", tokenString)
+			if os.Getenv("MINIMAL_OUTPUT") == "1" {
+				// for scripting
+				fmt.Printf("Bearer %s", tokenString)
+			} else {
+				log.Infof("Send the following HTTP header for JWT authorization:\n    Authorization: Bearer %s", tokenString)
+			}
 
 			return nil
 		},

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+############################## DEV_SCRIPT_MARKER ##############################
+# This script is used to document and run recurring tasks in development.     #
+#                                                                             #
+# You can run your tasks using the script `./dev some-task`.                  #
+# You can install the Sandstorm Dev Script Runner and run your tasks from any #
+# nested folder using `dev some-task`.                                        #
+# https://github.com/sandstorm/Sandstorm.DevScriptRunner                      #
+###############################################################################
+
+set -e
+
+######### TASKS #########
+
+function build() {
+  go build -o ./bin/prunner ./cmd/prunner
+  _log_success "Built ./bin/prunner"
+}
+
+function memory-leak-start() {
+  build
+
+
+  _log_success "Starting prunner on http://127.0.0.1:9009 with profiling enabled:"
+  _log_success " http://127.0.0.1:9009/debug/pprof/"
+  ./bin/prunner --path test/memory_leak_debugging --verbose --enable-profiling
+}
+
+function start-pipeline {
+  export PIPELINE_NAME=$1
+
+  if [  "$PIPELINE_NAME" == "" ]; then
+    _log_error "PIPELINE_NAME must be set in call to start-pipeline"
+    exit 1
+  fi
+
+  _log_warning "Generating auth token"
+  TOKEN=$(MINIMAL_OUTPUT=1 go run ./cmd/prunner debug)
+
+  _log_warning "Starting pipeline $PIPELINE_NAME"
+
+  curl -XPOST -H "Authorization: $TOKEN" -H "Content-type: application/json" -d "{
+   \"pipeline\": \"$PIPELINE_NAME\"
+  }" 'http://127.0.0.1:9009/pipelines/schedule'
+
+  curl -XGET -H "Authorization: $TOKEN" -H "Content-type: application/json" \
+    'http://127.0.0.1:9009/pipelines/jobs' | jq .
+}
+
+function analyze-heapdump {
+  DUMPNAME=heapdump-$(date +%s)
+  curl -o $DUMPNAME http://localhost:9009/debug/pprof/heap?gc=1
+  #curl -o $DUMPNAME http://localhost:9009/debug/pprof/allocs
+  PORT=$(jot -r 1  2000 65000)
+  go tool pprof -http=:$PORT $DUMPNAME
+}
+
+####### Utilities #######
+
+_log_success() {
+  printf "\033[0;32m%s\033[0m\n" "${1}"
+}
+_log_warning() {
+  printf "\033[1;33m%s\033[0m\n" "${1}"
+}
+_log_error() {
+  printf "\033[0;31m%s\033[0m\n" "${1}"
+}
+
+# THIS NEEDS TO BE LAST!!!
+# this will run your tasks
+"$@"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/taskctl/taskctl v1.3.1-0.20210426182424-d8747985c906
 	github.com/urfave/cli/v2 v2.4.0
 	gopkg.in/yaml.v2 v2.4.0
-	mvdan.cc/sh/v3 v3.4.3
+	mvdan.cc/sh/v3 v3.6.0
 )
 
 require (
@@ -44,9 +44,9 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/term v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -222,12 +224,16 @@ golang.org/x/sys v0.0.0-20210925032602-92d5a993a665/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb h1:PVGECzEo9Y3uOidtkHGdd347NjLtITfJFO9BxFpmRoo=
 golang.org/x/sys v0.0.0-20220403205710-6acee93ad0eb/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20191110171634-ad39bd3f0407/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210916214954-140adaaadfaf/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.3.0 h1:qoo4akIqOcDME5bhc/NgxUdovd6BSS2uMsVjB56q1xI=
+golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -264,3 +270,5 @@ mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91
 mvdan.cc/sh/v3 v3.1.1/go.mod h1:F+Vm4ZxPJxDKExMLhvjuI50oPnedVXpfjNSrusiTOno=
 mvdan.cc/sh/v3 v3.4.3 h1:zbuKH7YH9cqU6PGajhFFXZY7dhPXcDr55iN/cUAqpuw=
 mvdan.cc/sh/v3 v3.4.3/go.mod h1:p/tqPPI4Epfk2rICAe2RoaNd8HBSJ8t9Y2DA9yQlbzY=
+mvdan.cc/sh/v3 v3.6.0 h1:gtva4EXJ0dFNvl5bHjcUEvws+KRcDslT8VKheTYkbGU=
+mvdan.cc/sh/v3 v3.6.0/go.mod h1:U4mhtBLZ32iWhif5/lD+ygy1zrgaQhUu+XFy7C8+TTA=

--- a/taskctl/executor_test.go
+++ b/taskctl/executor_test.go
@@ -1,7 +1,6 @@
 package taskctl_test
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"testing"
@@ -22,14 +21,15 @@ func TestPgidExecutor_Execute(t *testing.T) {
 	to := 1 * time.Minute
 	job1.Timeout = &to
 
-	output, err := e.Execute(context.Background(), job1)
+	_, err = e.Execute(context.Background(), job1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !bytes.Contains(output, []byte("success")) {
-		t.Error()
-	}
+	// Disabled because of memory leak, see executor.go
+	//if !bytes.Contains(output, []byte("success")) {
+	//	t.Error()
+	//}
 
 	job1 = executor.NewJobFromCommand("exit 1")
 

--- a/taskctl/runner_test.go
+++ b/taskctl/runner_test.go
@@ -3,7 +3,6 @@ package taskctl
 import (
 	"fmt"
 	"io/ioutil"
-	"strings"
 	"testing"
 	"time"
 
@@ -80,9 +79,10 @@ func TestTaskRunner(t *testing.T) {
 			t.Error()
 		}
 
-		if !strings.Contains(testCase.t.Output(), testCase.output) {
-			t.Error()
-		}
+		// Disabled because of memory leak, see runner.go
+		//if !strings.Contains(testCase.t.Output(), testCase.output) {
+		//	t.Error("Expected: ", testCase.output, "Actual: ", testCase.t.Output())
+		//}
 
 		if testCase.errored && !testCase.t.Errored {
 			t.Error()

--- a/test/memory_leak_debugging/pipelines.yml
+++ b/test/memory_leak_debugging/pipelines.yml
@@ -1,0 +1,11 @@
+pipelines:
+  memleak1:
+    tasks:
+      lots_of_console_output:
+        script:
+          # generate 50 MB text
+          - /bin/bash -c "dd if=/dev/random bs=1M  count=50 | base64"
+      test:
+        script:
+          - sleep 2
+        depends_on: [ lots_of_console_output ]


### PR DESCRIPTION
This change is potentially breaking because it removes the `{{ .Output }}` and `{{ .Tasks.XYZ.Output }}` placeholders provided by taskctl. We however never announced this as "official functionality", thus I think it is safe to remove (and the benefits of no memory leaks greatly outweigh the costs for us).

In our case, prunner needed more than 8 GB of RAM after running for some days.

This change does the following:

- Add a (manual) test setup to try out memory handling See README section "Memory Leak Debugging" how to use this setup to debug Memory Leaks with the Go Profiler.

  This is implemented in `test/memory_leak_debugging/pipelines.yml` and `dev.sh`.

- `executor.go`: Remove the output byte buffer in `PgidExecutor` (which was needed for supporting `{{ .Output }}` and was one reason for the memory leak).

- `runner.go`: Do not fill `Task.Log.Stdout` and `Task.Log.Stderr` anymore. This struct was needed for implementing `{{ .Tasks.XYZ.Output }}`, and was the second reason for the huge memory leak.

Unrelated:

- If `prunner debug` is executed with `MINIMAL_OUTPUT=1`, this will output only the JWT token - so that it can be used in scripts (we needed this for memory leak debugging)

- Add TOC in README

- Update mvdan.cc/sh/v3 from 3.4.3 to 3.6.0 (as during debugging, I thought this might fix memory leaks).