### PR TITLE
Add `aarch64` release build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - aarch64
     main: ./cmd/prunner
 archives:
   - replacements:


### PR DESCRIPTION
Some docker containers claim to be `aarch64` (`uname -m`). This seems to be an inconsistent naming, as it means the same as `arm64` on other systems (AFAIK).