### PR TITLE
Task: Update to Go 1.20 and update linter and actions

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Deploy API documentation
         uses: bump-sh/github-action@v1
         with:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Comment pull request with API diff
         uses: bump-sh/github-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       -
@@ -29,9 +29,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.20
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
     tags:
       - v*
     branches:
+      - v*
       - main
   pull_request:
 
@@ -11,51 +12,46 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
-      - name: Checkout code
-        uses: actions/checkout@v2
+          go-version: '1.20'
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.52
 
   test:
     strategy:
       matrix:
-        go-version: [ '1.18']
+        go-version: [ '1.20', '1.19', '1.18']
         platform: [ 'ubuntu-latest' ]
     runs-on: ${{ matrix.platform }}
     steps:
+      - uses: actions/checkout@v3
       - name: Install Go
         if: success()
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Run tests
         run: go test -v -race ./...
 
   coverage:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
       - name: Install Go
         if: success()
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: '1.20'
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Calc coverage
         run: |
-          go test -v -covermode=count -coverprofile=coverage.out .
-      - name: Convert coverage.out to coverage.lcov
-        uses: jandelgado/gcov2lcov-action@v1.0.6
-      - name: Coveralls
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.github_token }}
-          path-to-lcov: coverage.lcov
+          go test -cover ./... -coverpkg=github.com/Flowpack/prunner/... -coverprofile=coverage.txt
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-<img src="docs/prunner-logo-light.png" width="320" align="center">
+<img src="docs/prunner-logo-light.png" alt="prunner" width="320" align="center">
+
+[![GoDoc](https://godoc.org/github.com/Flowpack/prunner?status.svg)](https://godoc.org/github.com/Flowpack/prunner)
+[![Build Status](https://github.com/Flowpack/prunner/workflows/Go/badge.svg)](https://github.com/Flowpack/prunner/actions?workflow=run%20tests)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Flowpack/prunner)](https://goreportcard.com/report/github.com/Flowpack/prunner)
 
 ---
 
@@ -390,7 +394,7 @@ Prunner can be started inside a container. There are a few things to consider:
   clients to generate correct JWT tokens based on the secret.
 * Alternatively a pre-generated secret can be passed via the `PRUNNER_JWT_SECRET` env var
   and shared with applications accessing the API.
-* The `--address` flag should be set to listen on all interfaces (.e.g. `:9009`) or a specific network address. 
+* The `--address` flag should be set to listen on all interfaces (.e.g. `:9009`) or a specific network address.
   This allows to access the API from outside the container.
 
 ## Development

--- a/definition/pipelines.go
+++ b/definition/pipelines.go
@@ -137,6 +137,7 @@ func (d PipelineDef) Equals(otherDef PipelineDef) bool {
 			return false
 		}
 	}
+	//nolint:gosimple // Keep the code structure with an explicit if for readability
 	if d.SourcePath != otherDef.SourcePath {
 		return false
 	}


### PR DESCRIPTION
* Update to use Go 1.20 for the builds (we keep `go 1.18` in `go.mod` for compatibility as a package)
* Update GitHub actions and linter
* Upload coverage to codecov