### PR TITLE
FEATURE: Partitioned Wait Lists

### DIFF
--- a/definition/loader_test.go
+++ b/definition/loader_test.go
@@ -23,3 +23,28 @@ func TestLoadRecursively_WithMissingDependency(t *testing.T) {
 	_, err := LoadRecursively("../test/fixtures/missingDep.yml")
 	require.EqualError(t, err, `loading ../test/fixtures/missingDep.yml: invalid pipeline definition "test_it": missing task "not_existing" referenced in depends_on of task "test"`)
 }
+
+func TestPartitionedWaitlist_OK(t *testing.T) {
+	_, err := LoadRecursively("../test/fixtures/partitioned_waitlist.yml")
+	require.NoError(t, err)
+}
+
+func TestPartitionedWaitlist_err_0_partition_limit(t *testing.T) {
+	_, err := LoadRecursively("../test/fixtures/partitioned_waitlist_err_0_partition_limit.yml")
+	require.EqualError(t, err, `loading ../test/fixtures/partitioned_waitlist_err_0_partition_limit.yml: invalid pipeline definition "test_it": queue_partition_limit must be defined and >=1 if queue_strategy=partitioned_replace`)
+}
+
+func TestPartitionedWaitlist_err_no_partition_limit(t *testing.T) {
+	_, err := LoadRecursively("../test/fixtures/partitioned_waitlist_err_no_partition_limit.yml")
+	require.EqualError(t, err, `loading ../test/fixtures/partitioned_waitlist_err_no_partition_limit.yml: invalid pipeline definition "test_it": queue_partition_limit must be defined and >=1 if queue_strategy=partitioned_replace`)
+}
+
+func TestPartitionedWaitlist_err_queue_limit(t *testing.T) {
+	_, err := LoadRecursively("../test/fixtures/partitioned_waitlist_err_queue_limit.yml")
+	require.EqualError(t, err, `loading ../test/fixtures/partitioned_waitlist_err_queue_limit.yml: invalid pipeline definition "test_it": queue_limit is not allowed if queue_strategy=partitioned_replace, use queue_partition_limit instead`)
+}
+
+func TestWaitlist_err_partitioned_queue_limit(t *testing.T) {
+	_, err := LoadRecursively("../test/fixtures/waitlist_err_partitioned_queue_limit.yml")
+	require.EqualError(t, err, `loading ../test/fixtures/waitlist_err_partitioned_queue_limit.yml: invalid pipeline definition "test_it": queue_partition_limit is not allowed if queue_strategy=append|replace, use queue_limit instead`)
+}

--- a/docs/2025_08_14_partitioned_waitlist.md
+++ b/docs/2025_08_14_partitioned_waitlist.md
@@ -1,0 +1,111 @@
+# FEATURE: Partitioned Waitlists
+
+
+# Problem description
+
+## Current state
+
+> **FROM README**
+>
+> By default, if you limit concurrency, and the limit is exceeded, further jobs are added to the
+> waitlist of the pipeline.
+> 
+> However, you have some options to configure this as well:
+> 
+> The waitlist can have a maximum size, denoted by `queue_limit`:
+> 
+> ```yaml
+> pipelines:
+>   do_something:
+>     queue_limit: 1
+>     concurrency: 1
+>     tasks: # as usual
+> ```
+> 
+> To deactivate the queuing altogether, set `queue_limit: 0`.
+> 
+> Now, if the queue is limited, an error occurs when it is full and you try to add a new job.
+> 
+> Alternatively, you can also set `queue_strategy: replace` to replace the last job in the
+> queue by the newly added one:
+
+## Current state -> Problem "Starvation" with "Debounce" ??
+
+> Queues a run of the job and only starts it after 10 seconds have passed (if no other run was triggered which replaced the queued job)
+
+```
+--> time (1 char = 1 s)
+
+# 1 waitlist slot, delay 10 s
+
+a____ _____ <-- here the job A is queued
+          A <-- here job A starts
+
+
+# 1 waitlist slot, delay 10 s
+# STARVATION CAN HAPPEN
+a____ b____ c_____ _____
+                       C
+                       
+
+# 2 waitlist slots, delay 10 s
+# !!! PREVENTS STARVATION !!!
+a____ b__c_ ______ _____
+[a_]  [ab]  A              <-- here, a starts. NO STARVATION 
+         [ac]              
+            [c_]
+```
+
+SUMMARY: 
+- Starvation can only happen if waitlist size=1; if waitlist size=2 (or bigger) cannot happen because always the LAST job gets replaced.
+- We cannot debounce immediately; so we ALWAYS wait at least for start_delay. (not a problem for us right now).
+ 
+## problem description
+
+In a project, we have 50 Neos instances, which use prunner for background tasks (some are short, some are long).
+
+Currently, we have 4 pipelines globally
+- concurrency 1
+- concurrency 8
+- concurrency 4
+- concurrency 4 (import job)
+  - -> needs the global concurrency to limit the needed server resources
+
+Now, a new pipeline should be added for "irregular import jobs" triggered by webhooks.
+- can happen very quickly after each other
+- -> Pipeline should start after a certain amount of time (newer should override older pipelines)
+- StartDelay combined with QueueStrategy "Replace"
+  - `waitList[len(waitList)-1] = job` -> *LAST* Element is replaced of wait list.
+- -> GLOBAL replacement does not work, because each job has arguments (which are relevant, i.e. tenant ID).
+
+We still want to have a GLOBAL CONCURRENCY LIMIT (per pipeline), but a WAITLIST per instance.
+
+
+## Solution Idea:
+
+we want to be able to SEGMENT the waitlist into different partitions. The `queue_strategy` and `queue_limit` should be per partition.
+`concurrency` stays per pipeline (as before)
+
+```
+**LOGICAL VIEW** (Idea)
+┌──────────────────────┐      ┌──────────────────────────────────────────────────┐
+│ Waitlist Instance 1  │      │          Pipeline (with concurrency 2)           │
+├──────────────────────┤      │                                                  │
+│ Waitlist Instance 2  │  ->  ├──────────────────────────────────────────────────┤
+├──────────────────────┤      │                                                  │
+│ Waitlist Instance 3  │      │                                                  │
+└──────────────────────┘      └──────────────────────────────────────────────────┘
+                                                                                  
+          if job is *delayed*,                                                    
+           stays in wait list                                                     
+            for this duration                                                     
+                                                                                  
+```
+
+Technically, we still have a SINGLE Wait List per pipeline, but the jobs can be partitioned by `waitlist_partition_id`.
+
+-> In this case, the `replace` strategy will replace the last element of the given partition.
+
+-> we create a new queueStrategy for the partitioned waitlist: `partitioned_replace`
+
+If we partition the waitlist, the waitlist can grow up to queue_limit * number of partitions.

--- a/helper/slice_utils/sliceUtils.go
+++ b/helper/slice_utils/sliceUtils.go
@@ -1,0 +1,11 @@
+package slice_utils
+
+func Filter[T any](s []T, p func(i T) bool) []T {
+	var result []T
+	for _, i := range s {
+		if p(i) {
+			result = append(result, i)
+		}
+	}
+	return result
+}

--- a/prunner.go
+++ b/prunner.go
@@ -792,7 +792,7 @@ func (r *PipelineRunner) resolveScheduleAction(pipeline string, ignoreStartDelay
 			return scheduleActionErrNoQueue
 		}
 
-		if len(waitList) > 0 {
+		if len(waitList) >= *pipelineDef.QueueLimit {
 			// queue full -> replace last element
 			return scheduleActionReplace
 		}

--- a/prunner.go
+++ b/prunner.go
@@ -199,9 +199,6 @@ const (
 	// scheduleActionQueue enqueues the job to the pipeline's waitlist
 	scheduleActionQueue
 
-	// TODO: never used, remove
-	scheduleActionQueueDelay
-
 	// scheduleActionReplace: replace the last job on the waitlist with this one
 	scheduleActionReplace
 
@@ -803,8 +800,6 @@ func (r *PipelineRunner) isSchedulable(pipeline string) bool {
 	case scheduleActionQueue:
 		fallthrough
 	case scheduleActionStart:
-		return true
-	case scheduleActionQueueDelay:
 		return true
 	}
 	return false

--- a/prunner.go
+++ b/prunner.go
@@ -193,11 +193,22 @@ type jobTasks []jobTask
 type scheduleAction int
 
 const (
+	// scheduleActionStart directly starts a job via PipelineRunner.startJob()
 	scheduleActionStart scheduleAction = iota
+
+	// scheduleActionQueue enqueues the job to the pipeline's waitlist
 	scheduleActionQueue
+
+	// TODO: never used, remove
 	scheduleActionQueueDelay
+
+	// scheduleActionReplace: replace the last job on the waitlist with this one
 	scheduleActionReplace
+
+	// scheduleActionNoQueue: error case, if queueing is not allowed (queue_limit=0) and a job is running
 	scheduleActionNoQueue
+
+	// scheduleActionQueueFull: error case, if queue_limit is reached (with append queue strategy)
 	scheduleActionQueueFull
 )
 
@@ -365,6 +376,7 @@ func buildPipelineGraph(id uuid.UUID, tasks jobTasks, vars map[string]interface{
 	return g, nil
 }
 
+// ReadJob loads the job identified by id and calls process() on it synchronously. All protected by the global r.mx mutex.
 func (r *PipelineRunner) ReadJob(id uuid.UUID, process func(j *PipelineJob)) error {
 	r.mx.RLock()
 	defer r.mx.RUnlock()

--- a/prunner_test.go
+++ b/prunner_test.go
@@ -1083,6 +1083,93 @@ func TestPipelineRunner_ScheduleAsync_WithStartDelay2QueueAndReplaceWillReplaceL
 	}, 1*time.Millisecond, "job3 did not finish")
 }
 
+func TestPipelineRunner_ScheduleAsync_PartitionedReplaceWorksAsExpected(t *testing.T) {
+	// QueuePartitionLimit = 2
+	// startDelay = 50ms
+	// --time--> (time flows from left to right)
+	// a(1) means: "add job 'a' to partition 1"
+	//
+	// The testcase does the following -> quickly sends N jobs to the queue:
+	// a(1)..b(2)..c(1)..d(2)..e(2)..f(1)
+	//                   ^^^ a,b,c,d still exist (no replacement yet)
+	//                        ^^^ d replaced by e, others not replaced.
+	//                              ^^^ c was replaced
+
+	var defs = &definition.PipelinesDef{
+		Pipelines: map[string]definition.PipelineDef{
+			"withReplacePartition": {
+				Concurrency:         1,
+				StartDelay:          50 * time.Millisecond,
+				QueuePartitionLimit: intPtr(2),                                  // !!! IMPORTANT for this testcase
+				QueueStrategy:       definition.QueueStrategyPartitionedReplace, // !!! IMPORTANT for this testcase
+				Tasks: map[string]definition.TaskDef{
+					"echo": {
+						Script: []string{"echo Test"},
+					},
+				},
+				SourcePath: "fixtures",
+			},
+		},
+	}
+	require.NoError(t, defs.Validate())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := test.NewMockStore()
+	pRunner, err := NewPipelineRunner(ctx, defs, func(j *PipelineJob) taskctl.Runner {
+		return &test.MockRunner{
+			OnRun: func(tsk *task.Task) error {
+				log.Debugf("Run task %s on job %s", tsk.Name, j.ID.String())
+				return nil
+			},
+		}
+	}, store, test.NewMockOutputStore())
+	require.NoError(t, err)
+
+	jobA, err := pRunner.ScheduleAsync("withReplacePartition", ScheduleOpts{QueuePartition: "1"})
+	require.NoError(t, err)
+	jobB, err := pRunner.ScheduleAsync("withReplacePartition", ScheduleOpts{QueuePartition: "2"})
+	require.NoError(t, err)
+	jobC, err := pRunner.ScheduleAsync("withReplacePartition", ScheduleOpts{QueuePartition: "1"})
+	require.NoError(t, err)
+	jobD, err := pRunner.ScheduleAsync("withReplacePartition", ScheduleOpts{QueuePartition: "2"})
+	require.NoError(t, err)
+
+	// jobs A-D not yet started, not canceled.
+	_ = pRunner.ReadJob(jobA.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+		assert.Nil(t, j.Start)
+	})
+	_ = pRunner.ReadJob(jobB.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+		assert.Nil(t, j.Start)
+	})
+	_ = pRunner.ReadJob(jobC.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+		assert.Nil(t, j.Start)
+	})
+	_ = pRunner.ReadJob(jobD.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+		assert.Nil(t, j.Start)
+	})
+
+	// push E(2) (replaces D(2))
+	jobE, err := pRunner.ScheduleAsync("withReplacePartition", ScheduleOpts{QueuePartition: "2"})
+	require.NoError(t, err)
+	_ = pRunner.ReadJob(jobD.ID, func(j *PipelineJob) {
+		assert.True(t, j.Canceled) // !! this changed now
+		assert.Nil(t, j.Start)
+	})
+	_ = pRunner.ReadJob(jobE.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+		assert.Nil(t, j.Start)
+	})
+
+	// push F(1) (replaces C(1))
+	// check that A,B,E,F were executed.
+}
+
 func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillNotRunConcurrently(t *testing.T) {
 	var defs = &definition.PipelinesDef{
 		Pipelines: map[string]definition.PipelineDef{

--- a/prunner_test.go
+++ b/prunner_test.go
@@ -914,7 +914,7 @@ func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillQueueSi
 		Pipelines: map[string]definition.PipelineDef{
 			"jobWithStartDelay": {
 				Concurrency:   1,
-				StartDelay:    50 * time.Millisecond,
+				StartDelay:    100 * time.Millisecond,
 				QueueLimit:    intPtr(1),
 				QueueStrategy: definition.QueueStrategyReplace,
 				Tasks: map[string]definition.TaskDef{

--- a/prunner_test.go
+++ b/prunner_test.go
@@ -958,6 +958,7 @@ func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillQueueSi
 	job2, err := pRunner.ScheduleAsync("jobWithStartDelay", ScheduleOpts{})
 	require.NoError(t, err)
 
+	// original "job" should be canceled
 	test.WaitForCondition(t, func() bool {
 		var canceled bool
 		_ = pRunner.ReadJob(jobID, func(j *PipelineJob) {
@@ -966,6 +967,7 @@ func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillQueueSi
 		return canceled
 	}, 1*time.Millisecond, "job is canceled")
 
+	// job2 is scheduled
 	job2ID := job2.ID
 	test.WaitForCondition(t, func() bool {
 		var started bool
@@ -975,6 +977,7 @@ func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillQueueSi
 		return !started
 	}, 1*time.Millisecond, "job2 is not started (queued)")
 
+	// job2 is started after ~50 ms (which the test does not check for ^^)
 	test.WaitForCondition(t, func() bool {
 		var started bool
 		_ = pRunner.ReadJob(job2ID, func(j *PipelineJob) {

--- a/prunner_test.go
+++ b/prunner_test.go
@@ -996,6 +996,93 @@ func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillQueueSi
 	}, 1*time.Millisecond, "job2 is finished")
 }
 
+func TestPipelineRunner_ScheduleAsync_WithStartDelay2QueueAndReplaceWillReplaceLastJob(t *testing.T) {
+	var defs = &definition.PipelinesDef{
+		Pipelines: map[string]definition.PipelineDef{
+			"jobWithStartDelay": {
+				Concurrency:   1,
+				StartDelay:    50 * time.Millisecond,
+				QueueLimit:    intPtr(2), // !!! IMPORTANT for this testcase
+				QueueStrategy: definition.QueueStrategyReplace,
+				Tasks: map[string]definition.TaskDef{
+					"echo": {
+						Script: []string{"echo Test"},
+					},
+				},
+				SourcePath: "fixtures",
+			},
+		},
+	}
+	require.NoError(t, defs.Validate())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := test.NewMockStore()
+	pRunner, err := NewPipelineRunner(ctx, defs, func(j *PipelineJob) taskctl.Runner {
+		return &test.MockRunner{
+			OnRun: func(tsk *task.Task) error {
+				log.Debugf("Run task %s on job %s", tsk.Name, j.ID.String())
+				return nil
+			},
+		}
+	}, store, test.NewMockOutputStore())
+	require.NoError(t, err)
+
+	// job1 + job2 + job3 is appended
+	job1, err := pRunner.ScheduleAsync("jobWithStartDelay", ScheduleOpts{})
+	require.NoError(t, err)
+
+	job2, err := pRunner.ScheduleAsync("jobWithStartDelay", ScheduleOpts{})
+	require.NoError(t, err)
+
+	job3, err := pRunner.ScheduleAsync("jobWithStartDelay", ScheduleOpts{})
+	require.NoError(t, err)
+
+	// job2 should be canceled
+	test.WaitForCondition(t, func() bool {
+		var canceled bool
+		_ = pRunner.ReadJob(job2.ID, func(j *PipelineJob) {
+			canceled = j.Canceled
+		})
+		return canceled
+	}, 1*time.Millisecond, "job2 was not canceled")
+
+	// when job2 was canceled, job1 should still be not canceled, and job3 also should be in the queue.
+	_ = pRunner.ReadJob(job1.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+	})
+	_ = pRunner.ReadJob(job2.ID, func(j *PipelineJob) {
+		assert.True(t, j.Canceled)
+	})
+	_ = pRunner.ReadJob(job3.ID, func(j *PipelineJob) {
+		assert.False(t, j.Canceled)
+	})
+
+	// we wait for job1 to be finished
+	test.WaitForCondition(t, func() bool {
+		var started bool
+		var running bool
+
+		_ = pRunner.ReadJob(job1.ID, func(j *PipelineJob) {
+			started = j.Start != nil
+			running = j.isRunning()
+		})
+		return started && !running
+	}, 1*time.Millisecond, "job1 did not finish")
+
+	test.WaitForCondition(t, func() bool {
+		var started bool
+		var running bool
+
+		_ = pRunner.ReadJob(job3.ID, func(j *PipelineJob) {
+			started = j.Start != nil
+			running = j.isRunning()
+		})
+		return started && !running
+	}, 1*time.Millisecond, "job3 did not finish")
+}
+
 func TestPipelineRunner_ScheduleAsync_WithStartDelayNoQueueAndReplaceWillNotRunConcurrently(t *testing.T) {
 	var defs = &definition.PipelinesDef{
 		Pipelines: map[string]definition.PipelineDef{

--- a/server/server.go
+++ b/server/server.go
@@ -90,6 +90,10 @@ type pipelinesScheduleRequest struct {
 		// Job variables
 		// example: {"tag_name": "v1.17.4", "databases": ["mysql", "postgresql"]}
 		Variables map[string]interface{} `json:"variables"`
+
+		// for queue_strategy=partitioned_replace, the queue partition to use for this job
+		// example: "tenant1"
+		QueuePartition string `json:"queuePartition"`
 	}
 }
 
@@ -135,7 +139,7 @@ func (s *server) pipelinesSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pJob, err := s.pRunner.ScheduleAsync(in.Body.Pipeline, prunner.ScheduleOpts{Variables: in.Body.Variables, User: user})
+	pJob, err := s.pRunner.ScheduleAsync(in.Body.Pipeline, prunner.ScheduleOpts{Variables: in.Body.Variables, QueuePartition: in.Body.QueuePartition, User: user})
 	if err != nil {
 		// TODO Send JSON error and include expected errors (see resolveScheduleAction)
 		if errors.Is(err, prunner.ErrShuttingDown) {

--- a/test/fixtures/partitioned_waitlist.yml
+++ b/test/fixtures/partitioned_waitlist.yml
@@ -1,0 +1,11 @@
+pipelines:
+  test_it:
+    queue_strategy: partitioned_replace
+    # keep two tasks in the queue PER PARTITION.
+    queue_partition_limit: 2
+    concurrency: 1
+
+    tasks:
+      test:
+        script:
+          - echo "Foo"

--- a/test/fixtures/partitioned_waitlist_err_0_partition_limit.yml
+++ b/test/fixtures/partitioned_waitlist_err_0_partition_limit.yml
@@ -1,0 +1,10 @@
+pipelines:
+  test_it:
+    queue_strategy: partitioned_replace
+    queue_partition_limit: 0 # !!! ERROR
+    concurrency: 1
+
+    tasks:
+      test:
+        script:
+          - echo "Foo"

--- a/test/fixtures/partitioned_waitlist_err_no_partition_limit.yml
+++ b/test/fixtures/partitioned_waitlist_err_no_partition_limit.yml
@@ -1,0 +1,10 @@
+pipelines:
+  test_it:
+    queue_strategy: partitioned_replace
+    # MISSING: queue_partition_limit: 2
+    concurrency: 1
+
+    tasks:
+      test:
+        script:
+          - echo "Foo"

--- a/test/fixtures/partitioned_waitlist_err_queue_limit.yml
+++ b/test/fixtures/partitioned_waitlist_err_queue_limit.yml
@@ -1,0 +1,10 @@
+pipelines:
+  test_it:
+    queue_strategy: partitioned_replace
+    queue_limit: 2 # not allowed in partitioned_replace
+    concurrency: 1
+
+    tasks:
+      test:
+        script:
+          - echo "Foo"

--- a/test/fixtures/waitlist_err_partitioned_queue_limit.yml
+++ b/test/fixtures/waitlist_err_partitioned_queue_limit.yml
@@ -1,0 +1,11 @@
+pipelines:
+  test_it:
+    queue_strategy: replace
+    # error: not allowed for queue_strategy: replace
+    queue_partition_limit: 2
+    concurrency: 1
+
+    tasks:
+      test:
+        script:
+          - echo "Foo"


### PR DESCRIPTION
If you have a multi-tenant application, you might want to use **one wait-list per tenant** (e.g. for import jobs),
combined with global `concurrency` limits (depending on the globally available server resources).

To enable this, do the following:

- `queue_strategy: partitioned_replace`: Enabled partitioned wait list
- `queue_partition_limit: 1` (or higher): Configure the number of wait-list slots per tenant. The last slot gets replaced
  when the wait-list is full.
- can be combined with arbitrary `start_delay` and `concurrency` as expected

Full example:

```
pipelines:
  do_something:
    queue_strategy: partitioned_replace
    # prevent starvation
    queue_partition_limit: 2
    concurrency: 1
    # Queues a run of the job and only starts it after 10 seconds have passed (if no other run was triggered which replaced the queued job)
    start_delay: 10s
    tasks: # as usual

```

Additionally, when submitting a job, you need to specify the `queuePartition` argument:

```
POST /pipelines/schedule

{
  "pipeline": "my_pipeline",
  "variables": {
    ...
  },
  "queuePartition": "tenant_foo"
}
```